### PR TITLE
Tab character now moves to tabstop.

### DIFF
--- a/src/vga/mod.rs
+++ b/src/vga/mod.rs
@@ -79,6 +79,7 @@ pub fn write(s: &str, x: uint, y: uint, fg: Colour, bg: Colour) {
             offset -= offset % COLS;
         } else if(c == '\t') {
             offset += 4;
+            offset -= offset % 4;
         } else if(c == '\0') {
             break;
         } else {


### PR DESCRIPTION
Now `\t` will move to the nearest 4-character-aligned column.

This relies on the fact that all VGA text mode widths are a multiple of 4, and so it's safe to perform this calculation on the offset rather than just the x-component of the offset.
