### PR TITLE
Fixed a link error on x64 linux by providing the target in LDFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RC := $(RUST_ROOT)/bin/rustc
 RCFLAGS := --opt-level=2 --target $(TARGET)
 
 LD := $(GCC_PREFIX)ld
-LDFLAGS := -nostdlib -Tsrc/linker.ld
+LDFLAGS := -nostdlib -m elf_i386 -Tsrc/linker.ld
 LIBS := $(shell $(GCC_PREFIX)gcc -print-file-name=libgcc.a)
 
 AS := $(LLVM_ROOT)/bin/clang


### PR DESCRIPTION
The error was (similar for every object file):

```
/usr/bin/ld: i386 architecture of input file `build/obj/src/main.o' is incompatible with i386:x86-64 output
```
