### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Rustic currently provides abstractions for:
  * Currently, timers merely call a function every N milliseconds, where N is decided by the machine-specific implementation.
 * GPIO on supported platforms (via `rustic::mach::Gpio` trait)
 * MMIO (via `rustic::mach::Mmio` trait)
- * This can be used to write to arbitary addresses and should be used with
+ * This can be used to write to arbitrary addresses and should be used with
  care.
 * Custom IRQ handling (via `rustic::mach::IrqHandler` trait)
 


### PR DESCRIPTION
@miselin, I've corrected a typographical error in the documentation of the [rustic](https://github.com/miselin/rustic) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.